### PR TITLE
Treat SliceIDs as Text to prevent JS compatibility issues

### DIFF
--- a/src/Fragnix/Slice.hs
+++ b/src/Fragnix/Slice.hs
@@ -51,7 +51,7 @@ data Name = Identifier Text | Operator Text
 
 type TypeName = Name
 
-type SliceID = Integer
+type SliceID = Text
 type SourceCode = Text
 type Qualification = Text
 type OriginalModule = Text

--- a/src/Fragnix/SliceCompiler.hs
+++ b/src/Fragnix/SliceCompiler.hs
@@ -338,7 +338,7 @@ sliceModulePath sliceID = sliceModuleDirectory </> sliceModuleName sliceID <.> "
 
 -- | The name we give to the module generated for a slice with the given ID.
 sliceModuleName :: SliceID -> String
-sliceModuleName sliceID = "F" ++ show sliceID
+sliceModuleName sliceID = "F" ++ unpack sliceID
 
 -- | The module name of the module that reexports all instances.
 allInstancesModuleName :: ModuleName ()
@@ -437,5 +437,3 @@ cFiles = [
     "myfree.c",
     "runProcess.c",
     "timeUtils.c"]
-
-


### PR DESCRIPTION
All modules in quick and packages could be sliced, although some tests in quick did not compile for lack of cbits (ancilData.c) and some modules in packages (Data.Type.Bool.hs, GHC.Types.hs) could not be parsed because the  ExplicitNamespaces Language extension was not enabled. 
But I don not think that this problem stems from the Data Type change.