### PR TITLE
Use encodePretty in order to obtain human readable slices

### DIFF
--- a/fragnix.cabal
+++ b/fragnix.cabal
@@ -38,6 +38,7 @@ library
                        haskell-names >=0.9.0 && <0.10,
                        tagged >=0.7.2 && <0.10,
                        aeson >=1.4 && <1.5,
+                       aeson-pretty >= 0.8 && <0.9,
                        bytestring >=0.10.4.0 && <0.11,
                        hashable >=1.3 && <1.4,
                        transformers >=0.3.0.0 && <0.6
@@ -61,6 +62,7 @@ executable fragnix
                        clock >=0.8 && <0.9,
                        tagged >=0.7.2 && <0.10,
                        aeson >=1.4 && <1.5,
+                       aeson-pretty >= 0.8 && <0.9,
                        bytestring >=0.10.4.0 && <0.11,
                        hashable >=1.3 && <1.4,
                        transformers >=0.3.0.0 && <0.6,
@@ -78,6 +80,7 @@ executable fragnix_hash_local_slices
                        bytestring >=0.10.4.0 && <0.11,
                        filepath >=1.3 && < 1.6,
                        aeson >=1.4 && <1.5,
+                       aeson-pretty >= 0.8 && <0.9,
                        fragnix
   hs-source-dirs:      utilities-src
   default-language:    Haskell2010
@@ -136,6 +139,7 @@ test-suite test
                        haskell-names >=0.9.0 && <0.10,
                        tagged >=0.7.2 && <0.10,
                        aeson >=1.4 && <1.5,
+                       aeson-pretty >= 0.8 && <0.9,
                        bytestring >=0.10.4.0 && <0.11,
                        hashable >=1.3 && <1.4,
                        transformers >=0.3.0.0 && <0.6,

--- a/src/Fragnix/Declaration.hs
+++ b/src/Fragnix/Declaration.hs
@@ -11,8 +11,9 @@ import Language.Haskell.Names (
   Symbol)
 
 import Data.Aeson (
-    ToJSON(toJSON),object,(.=),encode,
+    ToJSON(toJSON),object,(.=),
     FromJSON(parseJSON),withObject,(.:),decode)
+import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as ByteString (readFile,writeFile)
 import Data.Text (Text)
 import System.Directory (createDirectoryIfMissing)
@@ -49,7 +50,7 @@ readDeclarations declarationspath = do
 writeDeclarations :: FilePath -> [Declaration] -> IO ()
 writeDeclarations declarationspath declarations = do
     createDirectoryIfMissing True (dropFileName declarationspath)
-    ByteString.writeFile declarationspath (encode declarations)
+    ByteString.writeFile declarationspath (encodePretty declarations)
 
 instance ToJSON Declaration where
     toJSON (Declaration declarationgenre extensions declarationast declaredsymbols mentionedsymbols) = object [

--- a/src/Fragnix/Slice.hs
+++ b/src/Fragnix/Slice.hs
@@ -22,7 +22,8 @@ import Prelude hiding (writeFile,readFile)
 import Data.Aeson (
     ToJSON(toJSON),object,(.=),
     FromJSON(parseJSON),withObject,(.:),withText,
-    encode,eitherDecode)
+    eitherDecode)
+import Data.Aeson.Encode.Pretty (encodePretty)
 
 import GHC.Generics (Generic)
 import Data.Hashable (Hashable)
@@ -269,7 +270,7 @@ instance Exception SliceParseError
 writeSlice :: FilePath -> Slice -> IO ()
 writeSlice slicePath slice = do
     createDirectoryIfMissing True (dropFileName slicePath)
-    writeFile slicePath (encode slice)
+    writeFile slicePath (encodePretty slice)
 
 writeSliceDefault :: Slice -> IO ()
 writeSliceDefault slice@(Slice sliceID _ _ _ _) = writeSlice (sliceDefaultPath sliceID) slice


### PR DESCRIPTION
`encodePretty` is a drop-in replacement for Aeson's `encode` function which generates human-readable JSON.
This should simplify debugging and demoing. Performence regression should be negligeable for serializing / deserializing code snippets.

Closes #115 
Example output:

```
{
    "sliceID": "3058495352008825543",
    "uses": [
        {
            "reference": {
                "builtinModule": "GHC.Base"
            },
            "usedName": {
                "typeName": {
                    "identifier": "String"
                }
            },
            "qualification": null
        },
        {
            "reference": {
                "builtinModule": "GHC.Types"
            },
            "usedName": {
                "typeName": {
                    "identifier": "IO"
                }
            },
            "qualification": null
        },
        {
            "reference": {
                "builtinModule": "System.IO"
            },
            "usedName": {
                "valueName": {
                    "identifier": "putStrLn"
                }
            },
            "qualification": null
        },
        {
            "reference": {
                "builtinModule": "GHC.Base"
            },
            "usedName": {
                "valueName": {
                    "operator": "++"
                }
            },
            "qualification": null
        }
    ],
    "fragment": [
        "putHi :: String -> IO ()",
        "putHi x = putStrLn (\"Hi \" ++ x)"
    ],
    "instances": [],
    "language": {
        "extensions": [
            "MultiParamTypeClasses",
            "NondecreasingIndentation",
            "ExplicitForAll",
            "PatternGuards"
        ]
    }
}
```