### PR TITLE
Read and write slices to git-like subfolders

### DIFF
--- a/executable-src/Main.hs
+++ b/executable-src/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import Fragnix.Declaration (
     writeDeclarations)
 import Fragnix.Slice (
-    writeSliceDefault)
+    writeSlice)
 import Fragnix.Environment (
     loadEnvironment,persistEnvironment,
     environmentPath,builtinEnvironmentPath)
@@ -64,7 +64,7 @@ main = do
     let (localSlices, symbolLocalIDs) = declarationLocalSlices declarations
     let (localSliceIDMap, slices) = hashLocalSlices localSlices
     let symbolSliceIDs = lookupLocalIDs symbolLocalIDs localSliceIDMap
-    timeIt (for_ slices writeSliceDefault)
+    timeIt (for_ slices writeSlice)
 
     putStrLn "Updating environment ..."
 

--- a/gui-src/fragnix-browse.hs
+++ b/gui-src/fragnix-browse.hs
@@ -6,7 +6,7 @@ module Main where
 
 import Prelude hiding (writeFile,readFile)
 
-import Fragnix.Slice (Slice(..), SliceID, sliceDirectory)
+import Fragnix.Slice (Slice(..), SliceID, getSlices)
 import Fragnix.LocalSlice (LocalSlice, LocalSliceID)
 import Fragnix.HashLocalSlices (hashLocalSlices)
 
@@ -69,22 +69,6 @@ main = do
 -- | GET /contents implementation
 getSlicesHandler :: Handler [Slice]
 getSlicesHandler = liftIO getSlices
-
--- | return all slices in sliceDirectory
-getSlices :: IO [Slice]
-getSlices = do
-  allContents <- listDirectory sliceDirectory
-  allPaths <- return (map (sliceDirectory </>) allContents)
-  filePaths <- filterM doesFileExist allPaths
-  eitherSlices <- forM filePaths decodeSlice
-  -- ignore anything that's not a valid slice - let the elm part figure
-  -- out if the tree is complete
-  return (rights eitherSlices)
-
-decodeSlice :: FilePath -> IO (Either String Slice)
-decodeSlice p = do
-  file <- readFile p
-  evaluate (eitherDecode file)
 
 -- | POST /save implementation
 saveSlicesHandler :: Tuple [SliceID] [LocalSlice] -> Handler (Tuple [Tuple LocalSliceID SliceID] [Slice])

--- a/src/Fragnix/SliceCompiler.hs
+++ b/src/Fragnix/SliceCompiler.hs
@@ -9,7 +9,7 @@ import Fragnix.Slice (
     UsedName(ValueName,TypeName,ConstructorName),Name(Identifier,Operator),
     InstanceID,Instance(Instance),
     InstancePart(OfThisClass,OfThisClassForUnknownType,ForThisType,ForThisTypeOfUnknownClass),
-    readSliceDefault)
+    readSlice)
 
 import Prelude hiding (writeFile)
 
@@ -382,7 +382,7 @@ writeFileStrict filePath content = (do
 loadSlicesTransitive :: SliceID -> IO [Slice]
 loadSlicesTransitive sliceID = do
     sliceIDs <- loadSliceIDsTransitive sliceID
-    forM sliceIDs readSliceDefault
+    forM sliceIDs readSlice
 
 
 -- | Given a slice ID find all IDs of all the slices needed
@@ -398,7 +398,7 @@ loadSliceIDsStateful sliceID = do
     seenSliceIDs <- get
     unless (elem sliceID seenSliceIDs) (do
         put (sliceID : seenSliceIDs)
-        slice <- liftIO (readSliceDefault sliceID)
+        slice <- liftIO (readSlice sliceID)
         let recursiveSliceIDs = usedSliceIDs slice
             recursiveInstanceSliceIDs = sliceInstanceIDs slice
         forM_ recursiveSliceIDs loadSliceIDsStateful


### PR DESCRIPTION
Closes #140 

As it is currently implemented, the slice "12345" is put in the file "fragnix/slices/1/2/12345", i.e. the 12 prefix is not chopped off.

Since readSlice and writeSlice are not used anywhere, I renamed readSliceDefault and writeSliceDefault to readSlice and writeSlice.