### PR TITLE
Use cabal common-stanzas and SDPX licence identifier

### DIFF
--- a/fragnix.cabal
+++ b/fragnix.cabal
@@ -1,8 +1,9 @@
+cabal-version:       2.2
 name:                fragnix
 version:             0.1.0.0
 synopsis:            Immutable, fragment-based dependency management!
 -- description:
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              phischu
 maintainer:          pschuster@uni-koblenz.de
@@ -13,21 +14,9 @@ extra-source-files:  README.md
                      , gui-src/elm/dist/index.html
                      , gui-src/elm/dist/elm.min.js
                      , gui-src/elm/README.md
-cabal-version:       >=1.10
 tested-with: GHC == 7.8.4, GHC == 7.10.1, GHC == 8.0.1
 
-library
-  exposed-modules:     Fragnix.Slice,
-                       Fragnix.LocalSlice,
-                       Fragnix.Declaration,
-                       Fragnix.ModuleDeclarations,
-                       Fragnix.DeclarationLocalSlices,
-                       Fragnix.HashLocalSlices,
-                       Fragnix.LocalSliceModule,
-                       Fragnix.SliceCompiler,
-                       Fragnix.Environment,
-                       Fragnix.SliceSymbols
-  -- other-extensions:    
+common shared-build-depends
   build-depends:       base >=4.6 && <4.15,
                        text >=1.2 && < 1.3,
                        filepath >=1.3 && < 1.6,
@@ -41,29 +30,28 @@ library
                        bytestring >=0.10.4.0 && <0.11,
                        hashable >=1.3 && <1.4,
                        transformers >=0.3.0.0 && <0.6
-  hs-source-dirs:      src
   default-language:    Haskell2010
+
+library
+  import:              shared-build-depends
+  exposed-modules:     Fragnix.Slice,
+                       Fragnix.LocalSlice,
+                       Fragnix.Declaration,
+                       Fragnix.ModuleDeclarations,
+                       Fragnix.DeclarationLocalSlices,
+                       Fragnix.HashLocalSlices,
+                       Fragnix.LocalSliceModule,
+                       Fragnix.SliceCompiler,
+                       Fragnix.Environment,
+                       Fragnix.SliceSymbols
+  hs-source-dirs:      src
   ghc-options:         -O2 -Wall
 
 
 executable fragnix
+  import:              shared-build-depends
   main-is:             Main.hs
-  -- other-modules:
-  -- other-extensions:
-  build-depends:       base >=4.6 && <4.15,
-                       text >=1.2 && < 1.3,
-                       filepath >=1.3 && < 1.6,
-                       directory >=1.3 && < 1.4,
-                       process >=1.6 && <1.7,
-                       containers >=0.6 && <0.7,
-                       haskell-src-exts >=1.23 && <1.24,
-                       haskell-names >=0.9.0 && <0.10,
-                       clock >=0.8 && <0.9,
-                       tagged >=0.7.2 && <0.10,
-                       aeson >=1.4 && <1.5,
-                       bytestring >=0.10.4.0 && <0.11,
-                       hashable >=1.3 && <1.4,
-                       transformers >=0.3.0.0 && <0.6,
+  build-depends:       clock >=0.8 && <0.9,
                        fragnix
   hs-source-dirs:      executable-src
   default-language:    Haskell2010
@@ -71,94 +59,53 @@ executable fragnix
 
 
 executable fragnix_hash_local_slices
+  import:              shared-build-depends
   main-is:             fragnix_hash_local_slices.hs
-  -- other-modules:
-  -- other-extensions:
-  build-depends:       base >=4.6 && <4.15,
-                       bytestring >=0.10.4.0 && <0.11,
-                       filepath >=1.3 && < 1.6,
-                       aeson >=1.4 && <1.5,
-                       fragnix
+  build-depends:       fragnix
   hs-source-dirs:      utilities-src
-  default-language:    Haskell2010
   ghc-options:         -O2 -threaded -rtsopts
 
 
 -- executable fragnix-browse
+--   import:              shared-build-depends
 --   main-is:             fragnix-browse.hs
 --   other-modules:       Api, Helpers
---   -- other-extensions:
---   build-depends:       base >=4.6 && <4.15,
---                        bytestring >=0.10.4.0 && <0.11,
---                        filepath >=1.3 && < 1.6,
---                        aeson >=1.4 && < 1.5,
---                        containers >=0.6 && <0.7,
---                        clock >=0.8 && <0.9,
---                        directory >=1.3 && < 1.4,
+--   build-depends:       clock >=0.8 && <0.9,
 --                        either >= 5.0 && < 5.1,
 --                        servant >= 0.16 && < 0.17,
 --                        servant-server >= 0.16 && < 0.17,
 --                        servant-static-th >= 0.2.2 && < 0.2.3,
---                        text >=1.2 && < 1.3,
 --                        warp>=3.2.13 && <3.3,
 --                        fragnix
 --   hs-source-dirs:      gui-src
---   default-language:    Haskell2010
 --   ghc-options:         -O2 -threaded -rtsopts
 
 
 executable create_builtin_environment
+  import:              shared-build-depends
   main-is:             create_builtin_environment.hs
-  -- other-modules:
-  -- other-extensions:
-  build-depends:       base >=4.6 && <4.15,
-                       directory >=1.3 && < 1.4,
-                       containers >=0.6 && <0.7,
-                       haskell-src-exts >=1.23 && <1.24,
-                       haskell-names >=0.9.0 && <0.10,
-                       fragnix
+  build-depends:       fragnix
   hs-source-dirs:      utilities-src
-  default-language:    Haskell2010
   ghc-options:         -O2 -threaded -rtsopts -Wall
 
 
 test-suite test
+  import:              shared-build-depends
   main-is:             Main.hs
-  -- other-modules:
-  -- other-extensions:
-  build-depends:       base >=4.6 && <4.15,
-                       text >=1.2 && < 1.3,
-                       filepath >=1.3 && < 1.6,
-                       directory >=1.3 && < 1.4,
-                       process >=1.6 && <1.7,
-                       containers >=0.6 && <0.7,
-                       haskell-src-exts >=1.23 && <1.24,
-                       haskell-names >=0.9.0 && <0.10,
-                       tagged >=0.7.2 && <0.10,
-                       aeson >=1.4 && <1.5,
-                       bytestring >=0.10.4.0 && <0.11,
-                       hashable >=1.3 && <1.4,
-                       transformers >=0.3.0.0 && <0.6,
-                       tasty >=1.2 && <1.4,
+  build-depends:       tasty >=1.2 && <1.4,
                        tasty-golden >=2.2.2.4 && <2.4,
                        fragnix
   hs-source-dirs:      tests-src
-  default-language:    Haskell2010
   ghc-options:         -O2
   type:                exitcode-stdio-1.0
 
 
 benchmark benchmark
+  import:              shared-build-depends
   main-is:             Main.hs
-  build-depends:       base >=4.6 && <4.15,
-                       containers >=0.6 && <0.7,
-                       directory >=1.3 && <1.4,
-                       criterion >=1.5 && <1.6,
+  build-depends:       criterion >=1.5 && <1.6,
                        deepseq >=1.4.1.2 && <1.6,
-                       haskell-src-exts >=1.23 && <1.24,
-                       haskell-names >=0.9.0 && <0.10,
                        fragnix
   hs-source-dirs:      benchmarks-src
-  default-language:    Haskell2010
   ghc-options:         -O2
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
Use common stanza for shared build depends and default-language.