### PR TITLE
Change GHC outputdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ fragnix/cbits/*.o
 fragnix/environment/*
 fragnix/slices/*
 fragnix/temp/*
+fragnix/build/*
 gui-src/elm/elm-stuff
 tests/*/*/fragnix/*
 tests/quick/**/out

--- a/src/Fragnix/SliceCompiler.hs
+++ b/src/Fragnix/SliceCompiler.hs
@@ -60,6 +60,7 @@ invokeGHC :: SliceID -> IO ExitCode
 invokeGHC sliceID = rawSystem "ghc" [
     "-v0","-w",
     "-ifragnix/temp/compilationunits",
+    "-outputdir fragnix/build",
     sliceModulePath sliceID]
 
 -- | Invoke GHC to compile the slice with the given ID. The slice with the
@@ -73,6 +74,7 @@ invokeGHCMain sliceID = rawSystem "ghc" ([
     "-Ifragnix/include"] ++
     (map (\filename -> "fragnix/cbits/" ++ filename) cFiles) ++ [
     "-lpthread","-lz","-lutil",
+    "-outputdir fragnix/build",
     sliceModulePath sliceID])
 
 


### PR DESCRIPTION
Closes #84 

GHC output is redirected to "fragnix/build".